### PR TITLE
fix minified spaces and slice bundle size

### DIFF
--- a/index.js
+++ b/index.js
@@ -238,7 +238,7 @@ function print_block(node, css, indent_level) {
 		if (child.type === TYPE_DECLARATION) {
 			buffer += print_declaration(child, css, indent_level)
 
-			if (child === children.last) {
+			if (item.next === null) {
 				buffer += LAST_SEMICOLON
 			} else {
 				buffer += ';'

--- a/index.js
+++ b/index.js
@@ -119,7 +119,7 @@ function print_simple_selector(node, css) {
 	let buffer = EMPTY_STRING
 
 	if (node.children) {
-		for (let child of node.children) {
+		node.children.forEach((child) => {
 			switch (child.type) {
 				case 'Combinator': {
 					// putting spaces around `child.name` (+ > ~ or ' '), unless the combinator is ' '
@@ -190,7 +190,7 @@ function print_simple_selector(node, css) {
 					break
 				}
 			}
-		}
+		})
 	}
 
 	return buffer
@@ -454,10 +454,12 @@ function print_unknown(node, css, indent_level) {
  */
 function print(node, css, indent_level = 0) {
 	let buffer = EMPTY_STRING
+
+	/** @type {import('css-tree').List<import('css-tree').CssNode>} */
 	// @ts-expect-error Property 'children' does not exist on type 'AnPlusB', but we're never using that
 	let children = node.children
 
-	for (let child of children) {
+	children.forEach((child) => {
 		if (child.type === 'Rule') {
 			buffer += print_rule(child, css, indent_level)
 		} else if (child.type === 'Atrule') {
@@ -469,7 +471,7 @@ function print(node, css, indent_level = 0) {
 		if (child !== children.last) {
 			buffer += NEWLINE + NEWLINE
 		}
-	}
+	})
 
 	return buffer
 }
@@ -484,6 +486,7 @@ function print(node, css, indent_level = 0) {
  * @returns {string} The formatted CSS
  */
 export function format(css, { minify = false } = {}) {
+	/** @type {import('css-tree').CssNode} */
 	let ast = parse(css, {
 		positions: true,
 		parseAtrulePrelude: false,

--- a/test/minify.test.js
+++ b/test/minify.test.js
@@ -42,8 +42,8 @@ a {
 })
 
 test('correctly minifies operators', () => {
-	let actual = minify(`a { width: calc(100% - 10px); }`)
-	let expected = `a{width:calc(100% - 10px)}`
+	let actual = minify(`a { width: calc(100% - 10px); height: calc(100 * 1%); }`)
+	let expected = `a{width:calc(100% - 10px);height:calc(100*1%)}`
 	assert.equal(actual, expected)
 })
 

--- a/test/minify.test.js
+++ b/test/minify.test.js
@@ -12,13 +12,13 @@ test('empty rule', () => {
 
 test('simple declaration', () => {
 	let actual = minify(`:root { --color: red; }`)
-	let expected = `:root{--color:red;}`
+	let expected = `:root{--color:red}`
 	assert.equal(actual, expected)
 })
 
 test('simple atrule', () => {
 	let actual = minify(`@media (min-width: 100px) { body { color: red; } }`)
-	let expected = `@media (min-width: 100px){body{color:red;}}`
+	let expected = `@media (min-width: 100px){body{color:red}}`
 	assert.equal(actual, expected)
 })
 
@@ -37,8 +37,20 @@ a {
 20% green,100% yellow);
 }
 	`);
-	let expected = `a{background:linear-gradient(red, 10% blue, 20% green, 100% yellow);}`;
+	let expected = `a{background:linear-gradient(red,10% blue,20% green,100% yellow)}`;
 	assert.equal(actual, expected);
+})
+
+test('correctly minifies operators', () => {
+	let actual = minify(`a { width: calc(100% - 10px); }`)
+	let expected = `a{width:calc(100% - 10px)}`
+	assert.equal(actual, expected)
+})
+
+test('correctly minifiers modern colors', () => {
+	let actual = minify(`a { color: rgb(0 0 0 / 0.1); }`)
+	let expected = `a{color:rgb(0 0 0/0.1)}`
+	assert.equal(actual, expected)
 })
 
 test('Vadim Makeevs example works', () => {
@@ -55,13 +67,13 @@ test('Vadim Makeevs example works', () => {
 		}
 	}
 	`)
-	let expected = `@layer what{@container (width > 0){ul:has(:nth-child(1 of li)){@media (height > 0){&:hover{--is:this;}}}}}`
+	let expected = `@layer what{@container (width > 0){ul:has(:nth-child(1 of li)){@media (height > 0){&:hover{--is:this}}}}}`
 	assert.equal(actual, expected)
 })
 
 test('minified Vadims example', () => {
 	let actual = minify(`@layer what{@container (width>0){@media (min-height:.001px){ul:has(:nth-child(1 of li)):hover{--is:this}}}}`)
-	let expected = `@layer what{@container (width > 0){@media (min-height: .001px){ul:has(:nth-child(1 of li)):hover{--is:this;}}}}`
+	let expected = `@layer what{@container (width > 0){@media (min-height: .001px){ul:has(:nth-child(1 of li)):hover{--is:this}}}}`
 	assert.equal(actual, expected)
 })
 

--- a/test/values.test.js
+++ b/test/values.test.js
@@ -8,10 +8,12 @@ test('collapses abundant whitespace', () => {
 	let actual = format(`a {
 		transition: all   100ms   ease;
 		color: rgb(  0  ,  0   ,  0  );
+		color: red   ;
 	}`)
 	let expected = `a {
 	transition: all 100ms ease;
 	color: rgb(0, 0, 0);
+	color: red;
 }`
 	assert.is(actual, expected)
 })
@@ -99,12 +101,16 @@ test('formats whitespace around operators (*/+-) correctly', () => {
 	let actual = format(`a {
 	font: 2em/2 sans-serif;
 	font-size: calc(2em/2);
-	font-size: calc(2em + 2px)
+	font-size: calc(2em * 2);
+	font-size: calc(2em + 2px);
+	font-size: calc(2em - 2px);
 }`)
 	let expected = `a {
 	font: 2em/2 sans-serif;
 	font-size: calc(2em / 2);
+	font-size: calc(2em * 2);
 	font-size: calc(2em + 2px);
+	font-size: calc(2em - 2px);
 }`
 	assert.is(actual, expected)
 })


### PR DESCRIPTION
- minify spaces in value lists, closes #38 
- reduce bundle size by re-using `SPACE = ' '` and a bunch more strings

before

```
       1891 B: format.cjs.gz
       1699 B: format.cjs.br
       1303 B: format.modern.js.gz
       1199 B: format.modern.js.br
       1864 B: format.module.js.gz
       1666 B: format.module.js.br
       1940 B: format.umd.js.gz
       1748 B: format.umd.js.br

 4294  format.cjs
18306  format.cjs.map
 3142  format.modern.js
17615  format.modern.js.map
 4203  format.module.js
18312  format.module.js.map
 4500  format.umd.js
18309  format.umd.js.map
  762  index.d.ts
```

after

```
       1411 B: format.cjs.gz
       1282 B: format.cjs.br
       1359 B: format.modern.js.gz
       1240 B: format.modern.js.br
       1375 B: format.module.js.gz
       1258 B: format.module.js.br
       1485 B: format.umd.js.gz
       1354 B: format.umd.js.br

  3369  format.cjs
 19815  format.cjs.map
  3217  format.modern.js
 19796  format.modern.js.map
  3282  format.module.js
 19827  format.module.js.map
  3575  format.umd.js
 19818  format.umd.js.map
   762  index.d.ts
```

the 1kB size decrease is because we're no longer using for-loops which caused the inclusion of this huge polyfill:

```js
function r(e, r) {
  (null == r || r > e.length) && (r = e.length);
  for (var t = 0, n = new Array(r); t < r; t++) n[t] = e[t];
  return n;
}
function t(e, t) {
  var n =
    ("undefined" != typeof Symbol && e[Symbol.iterator]) || e["@@iterator"];
  if (n) return (n = n.call(e)).next.bind(n);
  if (
    Array.isArray(e) ||
    (n = (function (e, t) {
      if (e) {
        if ("string" == typeof e) return r(e, t);
        var n = Object.prototype.toString.call(e).slice(8, -1);
        return (
          "Object" === n && e.constructor && (n = e.constructor.name),
          "Map" === n || "Set" === n
            ? Array.from(e)
            : "Arguments" === n ||
              /^(?:Ui|I)nt(?:8|16|32)(?:Clamped)?Array$/.test(n)
            ? r(e, t)
            : void 0
        );
      }
    })(e)) ||
    (t && e && "number" == typeof e.length)
  ) {
    n && (e = n);
    var a = 0;
    return function () {
      return a >= e.length ? { done: !0 } : { done: !1, value: e[a++] };
    };
  }
  throw new TypeError(
    "Invalid attempt to iterate non-iterable instance.\nIn order to be iterable, non-array objects must have a [Symbol.iterator]() method."
  );
}
```