### PR TITLE
fix missing colon for formatting `:before` and `:after`

### DIFF
--- a/index.js
+++ b/index.js
@@ -141,7 +141,15 @@ function print_simple_selector(node, css) {
 				break
 			}
 			case 'PseudoClassSelector': {
-				buffer += ':' + child.name
+				buffer += ':'
+
+				// Special case for `:before` and `:after` which were used in CSS2 and are usually minified
+				// as `:before` and `:after`, but we want to keep them as `::before` and `::after`
+				if (child.name === 'before' || child.name === 'after') {
+					buffer += ':'
+				}
+
+				buffer += child.name
 
 				if (child.children) {
 					buffer += '(' + print_simple_selector(child, css) + ')'

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -73,6 +73,24 @@ test("formats nested selector combinators", () => {
 	}
 })
 
+test('formats pseudo selectors', () => {
+	let css = `
+		a::before,
+		a::after,
+		b:before,
+		b:after,
+		c::first-letter {}
+		`
+	let expected = `a::before,
+a::after,
+b::before,
+b::after,
+c::first-letter {}`
+
+	let actual = format(css)
+	assert.equal(actual, expected)
+})
+
 test("formats selectors with Nth", () => {
 	let fixtures = [
 		[`li:nth-child(3n-2) {}`, `li:nth-child(3n -2) {}`],


### PR DESCRIPTION
closes #42 