### PR TITLE
remove unknown print for rule prelude

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,9 +75,6 @@ export function format(css, { minify = false } = {}) {
 
 		if (prelude.type === TYPE_SELECTORLIST) {
 			buffer = print_selectorlist(prelude)
-		} else {
-			// In case parsing the selector list fails we'll print it as-is
-			buffer = print_unknown(prelude, indent_level)
 		}
 
 		if (block.type === TYPE_BLOCK) {

--- a/test/selectors.test.js
+++ b/test/selectors.test.js
@@ -168,4 +168,16 @@ li:nth-child() {}`
 	assert.equal(actual, expected)
 })
 
+test('formats unknown pseudos correctly', () => {
+	let actual = format(`
+		::foo-bar,
+		:unkown-thing(),
+		:unnowkn(kjsa.asddk,asd) {}
+	`)
+	let expected = `::foo-bar,
+:unkown-thing(),
+:unnowkn(kjsa.asddk,asd) {}`
+	assert.equal(actual, expected)
+})
+
 test.run()


### PR DESCRIPTION
not needed anymore since the csstree 3.0.0 upgrade and keeping it in decreases our coverage