### PR TITLE
perf: skip parsing atrule preludes

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,17 +1,4 @@
-import {
-	CSSNode,
-	parse,
-	ATTR_OPERATOR_EQUAL,
-	ATTR_OPERATOR_TILDE_EQUAL,
-	ATTR_OPERATOR_PIPE_EQUAL,
-	ATTR_OPERATOR_CARET_EQUAL,
-	ATTR_OPERATOR_DOLLAR_EQUAL,
-	ATTR_OPERATOR_STAR_EQUAL,
-	ATTR_FLAG_CASE_INSENSITIVE,
-	ATTR_FLAG_CASE_SENSITIVE,
-	NODE_TYPES as NODE,
-	DIMENSION,
-} from '@projectwallace/css-parser'
+import { CSSNode, parse, ATTR_OPERATOR_NAMES, ATTR_FLAG_NAMES, NODE_TYPES as NODE } from '@projectwallace/css-parser'
 
 const SPACE = ' '
 const EMPTY_STRING = ''
@@ -48,6 +35,7 @@ export function format(css: string, { minify = false, tab_size = undefined }: Fo
 	// First pass: collect all comments
 	let comments: number[] = []
 	let ast = parse(css, {
+		parse_atrule_preludes: false,
 		on_comment: minify
 			? undefined
 			: ({ start, end }) => {
@@ -212,24 +200,6 @@ export function format(css: string, { minify = false, tab_size = undefined }: Fo
 		return property + COLON + OPTIONAL_SPACE + value + important.join(EMPTY_STRING)
 	}
 
-	function print_attribute_selector_operator(operator: number) {
-		switch (operator) {
-			case ATTR_OPERATOR_TILDE_EQUAL:
-				return '~='
-			case ATTR_OPERATOR_PIPE_EQUAL:
-				return '|='
-			case ATTR_OPERATOR_CARET_EQUAL:
-				return '^='
-			case ATTR_OPERATOR_DOLLAR_EQUAL:
-				return '$='
-			case ATTR_OPERATOR_STAR_EQUAL:
-				return '*='
-			case ATTR_OPERATOR_EQUAL:
-			default:
-				return '='
-		}
-	}
-
 	function print_nth(node: CSSNode): string {
 		let parts = []
 		let a = node.nth_a
@@ -312,15 +282,13 @@ export function format(css: string, { minify = false, tab_size = undefined }: Fo
 				let parts = [OPEN_BRACKET, name.toLowerCase()]
 
 				if (node.attr_operator) {
-					parts.push(print_attribute_selector_operator(node.attr_operator))
+					parts.push(ATTR_OPERATOR_NAMES[node.attr_operator] ?? '')
 					if (typeof node.value === 'string') {
 						parts.push(print_string(node.value))
 					}
 
-					if (node.attr_flags === ATTR_FLAG_CASE_INSENSITIVE) {
-						parts.push(SPACE, 'i')
-					} else if (node.attr_flags === ATTR_FLAG_CASE_SENSITIVE) {
-						parts.push(SPACE, 's')
+					if (node.attr_flags) {
+						parts.push(SPACE, ATTR_FLAG_NAMES[node.attr_flags] ?? '')
 					}
 				}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "2.2.4",
 			"license": "MIT",
 			"dependencies": {
-				"@projectwallace/css-parser": "^0.13.4"
+				"@projectwallace/css-parser": "^0.13.5"
 			},
 			"devDependencies": {
 				"@codecov/vite-plugin": "^1.9.1",
@@ -1153,9 +1153,9 @@
 			}
 		},
 		"node_modules/@projectwallace/css-parser": {
-			"version": "0.13.4",
-			"resolved": "https://registry.npmjs.org/@projectwallace/css-parser/-/css-parser-0.13.4.tgz",
-			"integrity": "sha512-Xd8CqdLpnlXuJhYhbHxOw3j7ZsPS5nPPPCF+TKReLesCV6WbQVq0EI5B95bFXtmwX3SlmfZ4WYjyZxmqP/xRpw==",
+			"version": "0.13.5",
+			"resolved": "https://registry.npmjs.org/@projectwallace/css-parser/-/css-parser-0.13.5.tgz",
+			"integrity": "sha512-TJfTLKNWsoigjvb9tOVAu+6AVpGyf9FU4fIInJvI8ldSkqo9XE1jJJ8O9ucGBIMbD0pSVw8E86EMPdTATS0KYA==",
 			"license": "MIT"
 		},
 		"node_modules/@publint/pack": {

--- a/package.json
+++ b/package.json
@@ -60,6 +60,6 @@
 		"singleQuote": true
 	},
 	"dependencies": {
-		"@projectwallace/css-parser": "^0.13.4"
+		"@projectwallace/css-parser": "^0.13.5"
 	}
 }

--- a/test/atrules.test.ts
+++ b/test/atrules.test.ts
@@ -63,6 +63,16 @@ test('collapses whitespaces in prelude', () => {
 	expect(actual).toEqual(expected)
 })
 
+test('removes newlines in prelude', () => {
+	let actual = format(`@media
+		all,
+		screen,
+		print,
+		(min-width: 1000px) {}`)
+	let expected = `@media all, screen, print, (min-width: 1000px) {}`
+	expect(actual).toEqual(expected)
+})
+
 test('adds whitespace to @media (min-width:1000px)', () => {
 	let actual = format(`@media (min-width:1000px) {}`)
 	let expected = `@media (min-width: 1000px) {}`


### PR DESCRIPTION
We're not doing anything with the parsed atrule prelude information anyway, so might as well skip it

- updates css-parser to 0.13.5 to get a Raw .prelude node to get the .text from
- css-parser 0.13.5 exposes `ATTR_OPERATOR_NAMES` and `ATTR_FLAG_NAMES` so that saves some bytes to import