### PR TITLE
fix: avoid auth errors for npm publish action

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,11 +18,10 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
-          registry-url: https://registry.npmjs.org/
-      - run: npm install -g npm@latest
+          node-version: 24
       - run: npm ci --ignore-scripts --no-fund --no-audit
       - run: npm test
+      - run: npm run build
       - name: Bump version
         run: |
           VERSION=${GITHUB_REF_NAME#v}
@@ -34,5 +33,4 @@ jobs:
           git add package.json package-lock.json
           git commit -m "chore: bump version to ${GITHUB_REF_NAME#v}"
           git push origin HEAD:main
-      - run: npm run build
       - run: npm publish --access public


### PR DESCRIPTION
- node22 -> node24
- skip `npm i -g npm` because it fails
- remove `registry-url` because it causes auth errors
- move build step before versioning steps to avoid version bumps when build could potentially fail