### PR TITLE
Document partial formatters for individual CSS constructs

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ Need more examples?
 - [StackBlitz example using CommonJS](https://stackblitz.com/edit/stackblitz-starters-phchci?file=index.js)
 - [StackBlitz example using ES Modules](https://stackblitz.com/edit/stackblitz-starters-hrhsed?file=index.js)
 
+### Partial formatters
+
+The package also exports lower-level formatters for individual CSS constructs:
+
+```js
+import {
+  format_value,
+  format_declaration,
+  format_selector,
+  format_atrule_prelude,
+} from '@projectwallace/format-css'
+
+// Format a CSS value (e.g. the right-hand side of a declaration)
+format_value(nodes)
+
+// Format a single CSS declaration (property + value)
+format_declaration(node)
+
+// Format a single CSS selector
+format_selector(node)
+
+// Format an at-rule prelude (e.g. the query part of @media)
+format_atrule_prelude(prelude)
+```
+
+All of these accept the same options as `format()`. However, `tab_size` has no effect on them since they do not produce indented output.
+
+```js
+format_declaration(node, { minify: true })
+format_selector(node, { minify: true })
+```
+
 ## Formatting rules
 
 1. Every **AtRule** starts on a new line


### PR DESCRIPTION
## Summary
Added documentation for lower-level formatter functions that were previously undocumented. These partial formatters allow users to format individual CSS constructs rather than complete stylesheets.

## Changes
- Added new "Partial formatters" section to README.md with usage examples
- Documented four exported formatter functions:
  - `format_value()` - for formatting CSS values (right-hand side of declarations)
  - `format_declaration()` - for formatting individual CSS declarations
  - `format_selector()` - for formatting individual CSS selectors
  - `format_atrule_prelude()` - for formatting at-rule prelude content (e.g., @media queries)
- Clarified that these functions accept the same options as the main `format()` function
- Noted that `tab_size` option has no effect on partial formatters since they don't produce indented output
- Included code examples demonstrating usage with options like `minify`

## Details
This is purely documentation work that exposes existing functionality. The partial formatters were already exported from the package but lacked user-facing documentation and examples.

https://claude.ai/code/session_01AxMN3zd5sjBv8c4FqtiDp3