### PR TITLE
feat: expose format_value, format_declaration, format_selector and format_atrule_prelude

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,38 @@ Need more examples?
 - [StackBlitz example using CommonJS](https://stackblitz.com/edit/stackblitz-starters-phchci?file=index.js)
 - [StackBlitz example using ES Modules](https://stackblitz.com/edit/stackblitz-starters-hrhsed?file=index.js)
 
+### Partial formatters
+
+The package also exports lower-level formatters for individual CSS constructs:
+
+```js
+import {
+  format_value,
+  format_declaration,
+  format_selector,
+  format_atrule_prelude,
+} from '@projectwallace/format-css'
+
+// Format a CSS value (e.g. the right-hand side of a declaration)
+format_value(node.value)
+
+// Format a single CSS declaration (property + value)
+format_declaration(node)
+
+// Format a single CSS selector
+format_selector(node)
+
+// Format an at-rule prelude string (e.g. the query part of @media)
+format_atrule_prelude(node.prelude.text)
+```
+
+All of these accept the same options as `format()`. However, `tab_size` has no effect on them since they do not produce indented output.
+
+```js
+format_declaration(node, { minify: true })
+format_selector(node, { minify: true })
+```
+
 ## Formatting rules
 
 1. Every **AtRule** starts on a new line

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -56,6 +56,271 @@ export type FormatOptions = {
 	tab_size?: number
 }
 
+export function unquote(str: string): string {
+	return str.replace(/(?:^['"])|(?:['"]$)/g, EMPTY_STRING)
+}
+
+function print_string(str: string | number | null): string {
+	str = str?.toString() || ''
+	return QUOTE + unquote(str) + QUOTE
+}
+
+function print_operator(node: Operator, optional_space = SPACE): string {
+	// https://developer.mozilla.org/en-US/docs/Web/CSS/calc#notes
+	// The + and - operators must be surrounded by whitespace
+	// Whitespace around other operators is optional
+	let operator = node.text
+	let code = operator.charCodeAt(0)
+	// + or - require spaces; comma has no leading space; others use optional space
+	let space = code === 43 || code === 45 ? SPACE : optional_space
+	return (code === 44 ? EMPTY_STRING : space) + operator + space
+}
+
+function print_list(nodes: CSSNode[], optional_space = SPACE): string {
+	let parts = []
+	for (let node of nodes) {
+		if (is_function(node)) {
+			let fn = node.name.toLowerCase()
+			parts.push(fn, OPEN_PARENTHESES)
+			parts.push(print_list(node.children, optional_space))
+			parts.push(CLOSE_PARENTHESES)
+		} else if (is_dimension(node)) {
+			parts.push(node.value, node.unit?.toLowerCase())
+		} else if (is_string(node)) {
+			parts.push(print_string(node.text))
+		} else if (is_operator(node)) {
+			parts.push(print_operator(node, optional_space))
+		} else if (is_parenthesis(node)) {
+			parts.push(OPEN_PARENTHESES, print_list(node.children, optional_space), CLOSE_PARENTHESES)
+		} else if (is_url(node) && node.value) {
+			parts.push('url(')
+			let { value } = node
+			// if the value starts with data:, 'data:, "data:
+			if (/^['"]?data:/i.test(value)) {
+				parts.push(unquote(value))
+			} else {
+				parts.push(print_string(value))
+			}
+			parts.push(CLOSE_PARENTHESES)
+		} else {
+			parts.push(node.text)
+		}
+
+		if (!is_operator(node)) {
+			if (node.has_next) {
+				if (!is_operator(node.next_sibling)) {
+					parts.push(SPACE)
+				}
+			}
+		}
+	}
+
+	return parts.join(EMPTY_STRING)
+}
+
+export function format_value(
+	value: Value | Raw | null,
+	{ minify = false }: Pick<FormatOptions, 'minify'> = {},
+): string {
+	if (value === null || is_raw(value)) return EMPTY_STRING
+	let optional_space = minify ? EMPTY_STRING : SPACE
+	return print_list(value.children, optional_space)
+}
+
+export function format_declaration(
+	node: Declaration,
+	{ minify = false }: Pick<FormatOptions, 'minify'> = {},
+): string {
+	let optional_space = minify ? EMPTY_STRING : SPACE
+
+	let important = EMPTY_STRING
+	if (node.is_important) {
+		let text = node.text
+		let start = text.lastIndexOf('!')
+		important =
+			optional_space + text.slice(start, text.endsWith(SEMICOLON) ? -1 : undefined).toLowerCase()
+	}
+	let value = format_value(node.value, { minify })
+	let property = node.property!
+
+	// Special case for `font` shorthand: remove whitespace around /
+	if (property === 'font') {
+		value = value.replace(/\s*\/\s*/, '/')
+	}
+
+	// Hacky: add a space in case of a `space toggle` during minification
+	if (value === EMPTY_STRING && optional_space === EMPTY_STRING) {
+		value += SPACE
+	}
+
+	if (!property.startsWith('--')) {
+		property = property.toLowerCase()
+	}
+	return property + COLON + optional_space + value + important
+}
+
+function print_nth(node: NthSelector, optional_space = SPACE): string {
+	let a = node.nth_a
+	let b = node.nth_b
+	let result = a ? a : EMPTY_STRING
+	if (b) {
+		if (a) {
+			result += optional_space
+			if (!b.startsWith('-')) result += '+' + optional_space
+		}
+		// the parseFloat removes the leading '+', if present
+		result += parseFloat(b)
+	}
+	return result
+}
+
+function print_nth_of(node: NthOfSelector, optional_space = SPACE): string {
+	let result = EMPTY_STRING
+	if (node.nth) {
+		result = print_nth(node.nth, optional_space) + SPACE + 'of' + SPACE
+	}
+	if (node.selector) {
+		result += print_inline_selector_list(node.selector, optional_space)
+	}
+	return result
+}
+
+function print_simple_selector(
+	node: CSSNode,
+	optional_space = SPACE,
+	is_first: boolean = false,
+): string {
+	if (is_type_selector(node)) {
+		return node.name.toLowerCase()
+	}
+
+	if (is_combinator(node)) {
+		let text = node.text
+		// if only whitespace, return a single space
+		if (/^\s+$/.test(text)) {
+			return SPACE
+		}
+		// Skip leading space if this is the first node in the selector
+		let leading_space = is_first ? EMPTY_STRING : optional_space
+		return leading_space + text + optional_space
+	}
+
+	if (is_pseudo_class_selector(node) || is_pseudo_element_selector(node)) {
+		let parts = [COLON]
+		let name = node.name.toLowerCase()
+
+		// Legacy pseudo-elements or actual pseudo-elements use double colon
+		if (name === 'before' || name === 'after' || is_pseudo_element_selector(node)) {
+			parts.push(COLON)
+		}
+
+		parts.push(name)
+
+		if (node.has_children) {
+			parts.push(OPEN_PARENTHESES)
+			if (name === 'highlight') {
+				parts.push(print_list(node.children, optional_space))
+			} else {
+				parts.push(print_inline_selector_list(node, optional_space))
+			}
+			parts.push(CLOSE_PARENTHESES)
+		}
+
+		return parts.join(EMPTY_STRING)
+	}
+
+	if (is_attribute_selector(node)) {
+		let parts = [OPEN_BRACKET, node.name.toLowerCase()]
+
+		if (node.attr_operator) {
+			parts.push(node.attr_operator)
+			if (node.value !== null) {
+				parts.push(print_string(node.value))
+			}
+
+			if (node.attr_flags !== null) {
+				parts.push(SPACE, node.attr_flags.toLowerCase())
+			}
+		}
+
+		parts.push(CLOSE_BRACKET)
+		return parts.join(EMPTY_STRING)
+	}
+
+	return node.text
+}
+
+function print_inline_selector_list(
+	node: SelectorList | PseudoClassSelector | PseudoElementSelector,
+	optional_space = SPACE,
+): string {
+	let parts = []
+	for (let selector of node) {
+		parts.push(format_selector(selector, { minify: optional_space === EMPTY_STRING }))
+		if (selector.has_next) {
+			parts.push(COMMA, optional_space)
+		}
+	}
+	return parts.join(EMPTY_STRING)
+}
+
+export function format_selector(
+	node: CSSNode,
+	{ minify = false }: Pick<FormatOptions, 'minify'> = {},
+): string {
+	let optional_space = minify ? EMPTY_STRING : SPACE
+
+	if (is_nth_selector(node)) {
+		return print_nth(node, optional_space)
+	}
+
+	if (is_nth_of_selector(node)) {
+		return print_nth_of(node, optional_space)
+	}
+
+	if (is_selector_list(node)) {
+		return print_inline_selector_list(node, optional_space)
+	}
+
+	if (is_lang_selector(node)) {
+		return print_string(node.name)
+	}
+
+	// Handle compound selector (combination of simple selectors)
+	return (node as Selector).children
+		.map((child, i) => print_simple_selector(child, optional_space, i === 0))
+		.join(EMPTY_STRING)
+}
+
+/**
+ * Pretty-printing atrule preludes takes an insane amount of rules,
+ * so we're opting for a couple of 'good-enough' string replacements
+ * here to force some nice formatting.
+ * Should be OK perf-wise, since the amount of atrules in most
+ * stylesheets are limited, so this won't be called too often.
+ */
+export function format_atrule_prelude(
+	prelude: string,
+	{ minify = false }: Pick<FormatOptions, 'minify'> = {},
+): string {
+	let optional_space = minify ? EMPTY_STRING : SPACE
+	return prelude
+		.replace(/\s*([:,])/g, prelude.toLowerCase().includes('selector(') ? '$1' : '$1 ') // force whitespace after colon or comma, except inside `selector()`
+		.replace(/\)([a-zA-Z])/g, ') $1') // force whitespace between closing parenthesis and following text (usually and|or)
+		.replace(/\s*(=>|>=|<=)\s*/g, `${optional_space}$1${optional_space}`) // add optional spacing around =>, >= and <=
+		.replace(/([^<>=\s])([<>])([^<>=\s])/g, `$1${optional_space}$2${optional_space}$3`) // add spacing around < or > except when it's part of <=, >=, =>
+		.replace(/\s+/g, optional_space) // collapse multiple whitespaces into one
+		.replace(
+			/calc\(\s*([^()+\-*/]+)\s*([*/+-])\s*([^()+\-*/]+)\s*\)/g,
+			(_, left, operator, right) => {
+				// force required or optional whitespace around * and / in calc()
+				let space = operator === '+' || operator === '-' ? SPACE : optional_space
+				return `calc(${left.trim()}${space}${operator}${space}${right.trim()})`
+			},
+		)
+		.replace(/selector|url|supports|layer\(/gi, (match) => match.toLowerCase()) // lowercase function names
+}
+
 /**
  * Format a string of CSS using some simple rules
  */
@@ -121,223 +386,6 @@ export function format(
 		return buffer
 	}
 
-	function unquote(str: string): string {
-		return str.replace(/(?:^['"])|(?:['"]$)/g, EMPTY_STRING)
-	}
-
-	function print_string(str: string | number | null): string {
-		str = str?.toString() || ''
-		return QUOTE + unquote(str) + QUOTE
-	}
-
-	function print_operator(node: Operator): string {
-		// https://developer.mozilla.org/en-US/docs/Web/CSS/calc#notes
-		// The + and - operators must be surrounded by whitespace
-		// Whitespace around other operators is optional
-		let operator = node.text
-		let code = operator.charCodeAt(0)
-		// + or - require spaces; comma has no leading space; others use optional space
-		let space = code === 43 || code === 45 ? SPACE : OPTIONAL_SPACE
-		return (code === 44 ? EMPTY_STRING : space) + operator + space
-	}
-
-	function print_list(nodes: CSSNode[]): string {
-		let parts = []
-		for (let node of nodes) {
-			if (is_function(node)) {
-				let fn = node.name.toLowerCase()
-				parts.push(fn, OPEN_PARENTHESES)
-				parts.push(print_list(node.children))
-				parts.push(CLOSE_PARENTHESES)
-			} else if (is_dimension(node)) {
-				parts.push(node.value, node.unit?.toLowerCase())
-			} else if (is_string(node)) {
-				parts.push(print_string(node.text))
-			} else if (is_operator(node)) {
-				parts.push(print_operator(node))
-			} else if (is_parenthesis(node)) {
-				parts.push(OPEN_PARENTHESES, print_list(node.children), CLOSE_PARENTHESES)
-			} else if (is_url(node) && node.value) {
-				parts.push('url(')
-				let { value } = node
-				// if the value starts with data:, 'data:, "data:
-				if (/^['"]?data:/i.test(value)) {
-					parts.push(unquote(value))
-				} else {
-					parts.push(print_string(value))
-				}
-				parts.push(CLOSE_PARENTHESES)
-			} else {
-				parts.push(node.text)
-			}
-
-			if (!is_operator(node)) {
-				if (node.has_next) {
-					if (!is_operator(node.next_sibling)) {
-						parts.push(SPACE)
-					}
-				}
-			}
-		}
-
-		return parts.join(EMPTY_STRING)
-	}
-
-	function print_value(value: Value | Raw | null): string {
-		if (value === null || is_raw(value)) return EMPTY_STRING
-		return print_list(value.children)
-	}
-
-	function print_declaration(node: Declaration): string {
-		let important = EMPTY_STRING
-		if (node.is_important) {
-			let text = node.text
-			let start = text.lastIndexOf('!')
-			important =
-				OPTIONAL_SPACE + text.slice(start, text.endsWith(SEMICOLON) ? -1 : undefined).toLowerCase()
-		}
-		let value = print_value(node.value)
-		let property = node.property!
-
-		// Special case for `font` shorthand: remove whitespace around /
-		if (property === 'font') {
-			value = value.replace(/\s*\/\s*/, '/')
-		}
-
-		// Hacky: add a space in case of a `space toggle` during minification
-		if (value === EMPTY_STRING && minify === true) {
-			value += SPACE
-		}
-
-		if (!property.startsWith('--')) {
-			property = property.toLowerCase()
-		}
-		return property + COLON + OPTIONAL_SPACE + value + important
-	}
-
-	function print_nth(node: NthSelector): string {
-		let a = node.nth_a
-		let b = node.nth_b
-		let result = a ? `${a}` : EMPTY_STRING
-		if (b) {
-			if (a) {
-				result += OPTIONAL_SPACE
-				if (!b.startsWith('-')) result += '+' + OPTIONAL_SPACE
-			}
-			result += parseFloat(b)
-		}
-		return result
-	}
-
-	function print_nth_of(node: NthOfSelector): string {
-		let result = EMPTY_STRING
-		if (node.nth) {
-			result = print_nth(node.nth) + SPACE + 'of' + SPACE
-		}
-		if (node.selector) {
-			result += print_inline_selector_list(node.selector)
-		}
-		return result
-	}
-
-	function print_simple_selector(node: CSSNode, is_first: boolean = false): string {
-		if (is_type_selector(node)) {
-			return node.name.toLowerCase()
-		}
-
-		if (is_combinator(node)) {
-			let text = node.text
-			// if only whitespace, return a single space
-			if (/^\s+$/.test(text)) {
-				return SPACE
-			}
-			// Skip leading space if this is the first node in the selector
-			let leading_space = is_first ? EMPTY_STRING : OPTIONAL_SPACE
-			return leading_space + text + OPTIONAL_SPACE
-		}
-
-		if (is_pseudo_class_selector(node) || is_pseudo_element_selector(node)) {
-			let parts = [COLON]
-			let name = node.name.toLowerCase()
-
-			// Legacy pseudo-elements or actual pseudo-elements use double colon
-			if (name === 'before' || name === 'after' || is_pseudo_element_selector(node)) {
-				parts.push(COLON)
-			}
-
-			parts.push(name)
-
-			if (node.has_children) {
-				parts.push(OPEN_PARENTHESES)
-				if (name === 'highlight') {
-					parts.push(print_list(node.children))
-				} else {
-					parts.push(print_inline_selector_list(node))
-				}
-				parts.push(CLOSE_PARENTHESES)
-			}
-
-			return parts.join(EMPTY_STRING)
-		}
-
-		if (is_attribute_selector(node)) {
-			let parts = [OPEN_BRACKET, node.name.toLowerCase()]
-
-			if (node.attr_operator) {
-				parts.push(node.attr_operator)
-				if (node.value !== null) {
-					parts.push(print_string(node.value))
-				}
-
-				if (node.attr_flags !== null) {
-					parts.push(SPACE, node.attr_flags.toLowerCase())
-				}
-			}
-
-			parts.push(CLOSE_BRACKET)
-			return parts.join(EMPTY_STRING)
-		}
-
-		return node.text
-	}
-
-	function print_selector(node: CSSNode): string {
-		// Handle special selector types
-		if (is_nth_selector(node)) {
-			return print_nth(node)
-		}
-
-		if (is_nth_of_selector(node)) {
-			return print_nth_of(node)
-		}
-
-		if (is_selector_list(node)) {
-			return print_inline_selector_list(node)
-		}
-
-		if (is_lang_selector(node)) {
-			return print_string(node.name)
-		}
-
-		// Handle compound selector (combination of simple selectors)
-		return (node as Selector).children
-			.map((child, i) => print_simple_selector(child, i === 0))
-			.join(EMPTY_STRING)
-	}
-
-	function print_inline_selector_list(
-		node: SelectorList | PseudoClassSelector | PseudoElementSelector,
-	): string {
-		let parts = []
-		for (let selector of node) {
-			parts.push(print_selector(selector))
-			if (selector.has_next) {
-				parts.push(COMMA, OPTIONAL_SPACE)
-			}
-		}
-		return parts.join(EMPTY_STRING)
-	}
-
 	function print_selector_list(node: SelectorList): string {
 		let lines = []
 		let prev_end: number | undefined
@@ -349,7 +397,7 @@ export function format(
 				}
 			}
 
-			let printed = print_selector(selector)
+			let printed = format_selector(selector, { minify })
 			if (selector.has_next) {
 				printed += COMMA
 			}
@@ -391,7 +439,7 @@ export function format(
 
 			if (is_declaration(child)) {
 				let is_last = !child.has_next || !is_declaration(child.next_sibling)
-				let declaration = print_declaration(child)
+				let declaration = format_declaration(child, { minify })
 				let semi = is_last ? LAST_SEMICOLON : SEMICOLON
 				lines.push(indent(depth) + declaration + semi)
 			} else if (is_rule(child)) {
@@ -446,35 +494,10 @@ export function format(
 		return lines.join(NEWLINE)
 	}
 
-	/**
-	 * Pretty-printing atrule preludes takes an insane amount of rules,
-	 * so we're opting for a couple of 'good-enough' string replacements
-	 * here to force some nice formatting.
-	 * Should be OK perf-wise, since the amount of atrules in most
-	 * stylesheets are limited, so this won't be called too often.
-	 */
-	function print_atrule_prelude(prelude: string): string {
-		return prelude
-			.replace(/\s*([:,])/g, prelude.toLowerCase().includes('selector(') ? '$1' : '$1 ') // force whitespace after colon or comma, except inside `selector()`
-			.replace(/\)([a-zA-Z])/g, ') $1') // force whitespace between closing parenthesis and following text (usually and|or)
-			.replace(/\s*(=>|>=|<=)\s*/g, `${OPTIONAL_SPACE}$1${OPTIONAL_SPACE}`) // add optional spacing around =>, >= and <=
-			.replace(/([^<>=\s])([<>])([^<>=\s])/g, `$1${OPTIONAL_SPACE}$2${OPTIONAL_SPACE}$3`) // add spacing around < or > except when it's part of <=, >=, =>
-			.replace(/\s+/g, OPTIONAL_SPACE) // collapse multiple whitespaces into one
-			.replace(
-				/calc\(\s*([^()+\-*/]+)\s*([*/+-])\s*([^()+\-*/]+)\s*\)/g,
-				(_, left, operator, right) => {
-					// force required or optional whitespace around * and / in calc()
-					let space = operator === '+' || operator === '-' ? SPACE : OPTIONAL_SPACE
-					return `calc(${left.trim()}${space}${operator}${space}${right.trim()})`
-				},
-			)
-			.replace(/selector|url|supports|layer\(/gi, (match) => match.toLowerCase()) // lowercase function names
-	}
-
 	function print_atrule(node: Atrule): string {
 		let name = '@' + node.name!.toLowerCase()
 		if (node.prelude) {
-			name += SPACE + print_atrule_prelude(node.prelude.text)
+			name += SPACE + format_atrule_prelude(node.prelude.text, { minify })
 		}
 
 		let block_has_content =

--- a/test/api.test.ts
+++ b/test/api.test.ts
@@ -1,5 +1,14 @@
-import { test, expect } from 'vitest'
-import { format } from '../src/lib/index.js'
+import { test, expect, describe } from 'vitest'
+import { parse_selector, parse_declaration, parse_value } from '@projectwallace/css-parser'
+import {
+	format,
+	minify,
+	format_atrule_prelude,
+	format_selector,
+	format_declaration,
+	format_value,
+	unquote,
+} from '../src/lib/index.js'
 
 test('empty input', () => {
 	let actual = format(``)
@@ -41,7 +50,7 @@ test('Vadim Makeevs example works', () => {
 	expect(actual).toEqual(expected)
 })
 
-test('minified Vadims example', () => {
+test('format minified Vadims example', () => {
 	let actual = format(
 		`@layer what{@container (width>0){@media (min-height:.001px){ul:has(:nth-child(1 of li)):hover{--is:this}}}}`,
 	)
@@ -56,4 +65,169 @@ test('minified Vadims example', () => {
 	}
 }`
 	expect(actual).toEqual(expected)
+})
+
+test('minify keeps already-minified CSS unchanged', () => {
+	let input = `@layer what{@container (width>0){@media (min-height:.001px){ul:has(:nth-child(1 of li)):hover{--is:this}}}}`
+	let actual = minify(input)
+	expect(actual).toEqual(input)
+})
+
+describe('format_atrule_prelude', () => {
+	test('adds space after colon', () => {
+		expect(format_atrule_prelude('(min-height:.001px)')).toBe('(min-height: .001px)')
+	})
+
+	test('adds space after comma', () => {
+		expect(format_atrule_prelude('screen,print')).toBe('screen, print')
+	})
+
+	test('does not add space after colon inside selector()', () => {
+		expect(format_atrule_prelude('selector(:hover)')).toBe('selector(:hover)')
+	})
+
+	test('adds space around > comparison operator', () => {
+		expect(format_atrule_prelude('(width>0)')).toBe('(width > 0)')
+	})
+
+	test('adds space around >= operator', () => {
+		expect(format_atrule_prelude('(width>=300px)')).toBe('(width >= 300px)')
+	})
+
+	test('removes space around >= when minified', () => {
+		expect(format_atrule_prelude('(width >= 300px)', { minify: true })).toBe('(width>=300px)')
+	})
+
+	test('collapses multiple spaces', () => {
+		expect(format_atrule_prelude('screen  and  print')).toBe('screen and print')
+	})
+
+	test('adds space between ) and following word', () => {
+		expect(format_atrule_prelude('(width > 0)and(height > 0)')).toBe('(width > 0) and(height > 0)')
+	})
+
+	test('lowercases function names', () => {
+		expect(format_atrule_prelude('LAYER(default)')).toBe('layer(default)')
+		expect(format_atrule_prelude('SUPPORTS(display: grid)')).toBe('supports(display: grid)')
+	})
+
+	test('calc with + always keeps spaces', () => {
+		expect(format_atrule_prelude('calc(1px+2px)')).toBe('calc(1px + 2px)')
+		expect(format_atrule_prelude('calc(1px+2px)', { minify: true })).toBe('calc(1px + 2px)')
+	})
+
+	test('calc with * uses optional space', () => {
+		expect(format_atrule_prelude('calc(1px*2)')).toBe('calc(1px * 2)')
+		expect(format_atrule_prelude('calc(1px*2)', { minify: true })).toBe('calc(1px*2)')
+	})
+})
+
+describe('format_selector', () => {
+	test('type selector', () => {
+		let node = parse_selector('div').children[0]!
+		expect(format_selector(node)).toBe('div')
+	})
+
+	test('class selector', () => {
+		let node = parse_selector('.foo').children[0]!
+		expect(format_selector(node)).toBe('.foo')
+	})
+
+	test('combinator keeps spaces by default', () => {
+		let node = parse_selector('div > span').children[0]!
+		expect(format_selector(node)).toBe('div > span')
+	})
+
+	test('combinator removes spaces when minified', () => {
+		let node = parse_selector('div > span').children[0]!
+		expect(format_selector(node, { minify: true })).toBe('div>span')
+	})
+
+	test('selector list', () => {
+		let node = parse_selector('div, span')
+		expect(format_selector(node)).toBe('div, span')
+	})
+
+	test('selector list minified', () => {
+		let node = parse_selector('div, span')
+		expect(format_selector(node, { minify: true })).toBe('div,span')
+	})
+
+	test('pseudo-class', () => {
+		let node = parse_selector('a:hover').children[0]!
+		expect(format_selector(node)).toBe('a:hover')
+	})
+})
+
+describe('format_declaration', () => {
+	test('basic property and value', () => {
+		let node = parse_declaration('color: red')
+		expect(format_declaration(node)).toBe('color: red')
+	})
+
+	test('minified removes space after colon', () => {
+		let node = parse_declaration('color: red')
+		expect(format_declaration(node, { minify: true })).toBe('color:red')
+	})
+
+	test('uppercased property is lowercased', () => {
+		let node = parse_declaration('COLOR: red')
+		expect(format_declaration(node)).toBe('color: red')
+	})
+
+	test('custom property preserves casing', () => {
+		let node = parse_declaration('--myVar: 1')
+		expect(format_declaration(node)).toBe('--myVar: 1')
+	})
+
+	test('!important', () => {
+		let node = parse_declaration('color: red !IMPORTANT')
+		expect(format_declaration(node)).toBe('color: red !important')
+	})
+
+	test('!important minified', () => {
+		let node = parse_declaration('color: red !important')
+		expect(format_declaration(node, { minify: true })).toBe('color:red!important')
+	})
+})
+
+describe('format_value', () => {
+	test('null returns empty string', () => {
+		expect(format_value(null)).toBe('')
+	})
+
+	test('simple keyword', () => {
+		let value = parse_value('red')
+		expect(format_value(value)).toBe('red')
+	})
+
+	test('calc with + always keeps spaces', () => {
+		let value = parse_value('calc(1px + 2px)')
+		expect(format_value(value)).toBe('calc(1px + 2px)')
+		expect(format_value(value, { minify: true })).toBe('calc(1px + 2px)')
+	})
+
+	test('calc with * uses optional space', () => {
+		let value = parse_value('calc(1px * 2)')
+		expect(format_value(value)).toBe('calc(1px * 2)')
+		expect(format_value(value, { minify: true })).toBe('calc(1px*2)')
+	})
+})
+
+describe('unquote', () => {
+	test('removes double quotes', () => {
+		expect(unquote('"hello"')).toBe('hello')
+	})
+
+	test('removes single quotes', () => {
+		expect(unquote("'hello'")).toBe('hello')
+	})
+
+	test('no-op when no quotes', () => {
+		expect(unquote('bare')).toBe('bare')
+	})
+
+	test('removes only surrounding quotes, not inner ones', () => {
+		expect(unquote('"it\'s"')).toBe("it's")
+	})
 })


### PR DESCRIPTION
This is a re-creation of #191 

## Summary
This PR refactors the CSS formatting library to extract lower-level formatting functions as public exports and improves type safety by using type guards instead of node type constants.

## Key Changes

- **Extracted public formatting functions**: `format_value()`, `format_declaration()`, `format_selector()`, `format_atrule_prelude()`, and `unquote()` are now exported as standalone functions that can be used independently of the main `format()` function
- **Replaced type checking with type guards**: Changed from checking `node.type === NODE.CONSTANT` to using type guard functions like `is_function()`, `is_declaration()`, `is_rule()`, etc., improving type safety and reducing reliance on magic constants
- **Updated imports from css-parser**: Now imports type guards and type definitions directly from `@projectwallace/css-parser` instead of node type constants
- **Improved function signatures**: Formatting functions now accept `FormatOptions` parameter for consistent minification control across all formatters
- **Updated dependencies**: Bumped `@projectwallace/css-parser` from `^0.13.5` to `~0.14.7` to support new type guards and types
- **Enhanced test coverage**: Added comprehensive tests for all newly exported functions including `format_atrule_prelude()`, `format_selector()`, `format_declaration()`, `format_value()`, and `unquote()`
- **Updated documentation**: Added README section documenting the new partial formatters API

## Implementation Details

- The refactored functions maintain backward compatibility with the existing `format()` and `minify()` APIs
- Type guards provide better IDE support and compile-time safety compared to runtime type checking
- All formatting logic remains unchanged; this is purely a refactoring for better API design and maintainability
- Version bumped to 3.0.2 as a minor feature release

https://claude.ai/code/session_01M2d2VuMLMKQSFTL7GniQny