### PR TITLE
Add support for formatting CSS namespace selectors

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -188,12 +188,12 @@ function print_simple_selector(
 	is_first: boolean = false,
 ): string {
 	if (is_type_selector(node)) {
-		let prefix = node.namespace !== null ? node.namespace.toLowerCase() + '|' : ''
+		let prefix = node.namespace === null ? '' : node.namespace.toLowerCase() + '|'
 		return prefix + node.name.toLowerCase()
 	}
 
 	if (is_universal_selector(node)) {
-		let prefix = node.namespace !== null ? node.namespace.toLowerCase() + '|' : ''
+		let prefix = node.namespace === null ? '' : node.namespace.toLowerCase() + '|'
 		return prefix + '*'
 	}
 

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -24,6 +24,7 @@ import {
 	type StyleSheet,
 	type CSSNode,
 	is_type_selector,
+	is_universal_selector,
 	is_combinator,
 	is_pseudo_class_selector,
 	is_pseudo_element_selector,
@@ -187,7 +188,13 @@ function print_simple_selector(
 	is_first: boolean = false,
 ): string {
 	if (is_type_selector(node)) {
-		return node.name.toLowerCase()
+		let prefix = node.namespace !== null ? node.namespace.toLowerCase() + '|' : ''
+		return prefix + node.name.toLowerCase()
+	}
+
+	if (is_universal_selector(node)) {
+		let prefix = node.namespace !== null ? node.namespace.toLowerCase() + '|' : ''
+		return prefix + '*'
 	}
 
 	if (is_combinator(node)) {

--- a/test/selectors.test.ts
+++ b/test/selectors.test.ts
@@ -260,3 +260,17 @@ test('handles syntax errors', () => {
 	let expected = `test {}`
 	expect(actual).toEqual(expected)
 })
+
+test.each([
+	[`ns|div {}`, `ns|div {}`],
+	[`NS|div {}`, `ns|div {}`],
+	[`*|div {}`, `*|div {}`],
+	[`|div {}`, `|div {}`],
+	[`ns|* {}`, `ns|* {}`],
+	[`*|* {}`, `*|* {}`],
+	[`|* {}`, `|* {}`],
+	[`ns|div, ns|span {}`, `ns|div,\nns|span {}`],
+])('formats namespace selectors: %s', (css, expected) => {
+	let actual = format(css)
+	expect(actual).toEqual(expected)
+})


### PR DESCRIPTION
## Summary
This PR adds support for properly formatting CSS namespace selectors, including type selectors and universal selectors with namespace prefixes.

## Key Changes
- Updated `print_simple_selector()` function to handle namespace prefixes for both type selectors (e.g., `ns|div`) and universal selectors (e.g., `ns|*`)
- Namespace prefixes are normalized to lowercase to match CSS specification conventions
- Added import for `is_universal_selector` utility function
- Added comprehensive test coverage for namespace selector formatting, including:
  - Named namespace prefixes (`ns|div`, `ns|*`)
  - Universal namespace prefix (`*|div`, `*|*`)
  - Empty namespace prefix (`|div`, `|*`)
  - Multiple selectors with namespaces (`ns|div, ns|span`)

## Implementation Details
- Namespace prefixes are extracted from the node's `namespace` property and converted to lowercase before being prepended to the selector name
- The implementation handles both type selectors and universal selectors consistently
- Selectors without namespaces (where `namespace` is `null`) are formatted as before

https://claude.ai/code/session_01HfazKmPqWt1wtBF3ZUJ53P