### PR TITLE
Improve URL formatting with smart quote selection for data URIs

### DIFF
--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -35,6 +35,7 @@ import {
 	type Atrule,
 	type StyleSheet,
 	type CSSNode,
+	type Url,
 } from '@projectwallace/css-parser'
 
 const SPACE = ' '
@@ -66,6 +67,29 @@ function print_string(str: string | number | null): string {
 	return QUOTE + unquote(str) + QUOTE
 }
 
+function print_url(node: Url): string {
+	let unquoted = unquote(node.value)
+	let has_double = unquoted.includes('"')
+	let has_single = unquoted.includes("'")
+
+	let inner: string
+	if (/^['"]?data:/i.test(node.value)) {
+		if (!has_double && !has_single) {
+			inner = unquoted
+		} else if (!has_double) {
+			inner = '"' + unquoted + '"'
+		} else if (!has_single) {
+			inner = "'" + unquoted + "'"
+		} else {
+			inner = '"' + unquoted.replaceAll('"', '%22') + '"'
+		}
+	} else {
+		inner = print_string(node.value)
+	}
+
+	return 'url(' + inner + CLOSE_PARENTHESES
+}
+
 function print_operator(node: Operator, optional_space = SPACE): string {
 	// https://developer.mozilla.org/en-US/docs/Web/CSS/calc#notes
 	// The + and - operators must be surrounded by whitespace
@@ -94,15 +118,7 @@ function print_list(nodes: CSSNode[], optional_space = SPACE): string {
 		} else if (is_parenthesis(node)) {
 			parts.push(OPEN_PARENTHESES, print_list(node.children, optional_space), CLOSE_PARENTHESES)
 		} else if (is_url(node) && node.value) {
-			parts.push('url(')
-			let { value } = node
-			// if the value starts with data:, 'data:, "data:
-			if (/^['"]?data:/i.test(value)) {
-				parts.push(unquote(value))
-			} else {
-				parts.push(print_string(value))
-			}
-			parts.push(CLOSE_PARENTHESES)
+			parts.push(print_url(node))
 		} else {
 			parts.push(node.text)
 		}

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -68,23 +68,24 @@ function print_string(str: string | number | null, quote: '"' | "'" = '"'): stri
 }
 
 function print_url(node: Url): string {
-	let unquoted = unquote(node.value)
+	let value = node.value ?? ''
+	let unquoted = unquote(value)
 
 	let inner: string
-	if (/^['"]?data:/i.test(node.value)) {
+	if (/^['"]?data:/i.test(value)) {
 		let has_double = unquoted.includes('"')
 		let has_single = unquoted.includes("'")
-		if (!has_double && !has_single) {
-			inner = unquoted
-		} else if (!has_double) {
-			inner = print_string(unquoted, '"')
-		} else if (!has_single) {
-			inner = print_string(unquoted, "'")
-		} else {
+		if (has_double && has_single) {
 			inner = print_string(unquoted.replaceAll('"', '%22'), '"')
+		} else if (has_double) {
+			inner = print_string(unquoted, "'")
+		} else if (has_single) {
+			inner = print_string(unquoted, '"')
+		} else {
+			inner = unquoted
 		}
 	} else {
-		inner = print_string(node.value)
+		inner = print_string(value)
 	}
 
 	return 'url(' + inner + CLOSE_PARENTHESES

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -62,9 +62,9 @@ export function unquote(str: string): string {
 	return str.replaceAll(/(?:^['"])|(?:['"]$)/g, EMPTY_STRING)
 }
 
-function print_string(str: string | number | null): string {
+function print_string(str: string | number | null, quote: '"' | "'" = '"'): string {
 	str = str?.toString() || ''
-	return QUOTE + unquote(str) + QUOTE
+	return quote + unquote(str) + quote
 }
 
 function print_url(node: Url): string {
@@ -77,11 +77,11 @@ function print_url(node: Url): string {
 		if (!has_double && !has_single) {
 			inner = unquoted
 		} else if (!has_double) {
-			inner = '"' + unquoted + '"'
+			inner = print_string(unquoted, '"')
 		} else if (!has_single) {
-			inner = "'" + unquoted + "'"
+			inner = print_string(unquoted, "'")
 		} else {
-			inner = '"' + unquoted.replaceAll('"', '%22') + '"'
+			inner = print_string(unquoted.replaceAll('"', '%22'), '"')
 		}
 	} else {
 		inner = print_string(node.value)

--- a/src/lib/index.ts
+++ b/src/lib/index.ts
@@ -69,11 +69,11 @@ function print_string(str: string | number | null, quote: '"' | "'" = '"'): stri
 
 function print_url(node: Url): string {
 	let unquoted = unquote(node.value)
-	let has_double = unquoted.includes('"')
-	let has_single = unquoted.includes("'")
 
 	let inner: string
 	if (/^['"]?data:/i.test(node.value)) {
+		let has_double = unquoted.includes('"')
+		let has_single = unquoted.includes("'")
 		if (!has_double && !has_single) {
 			inner = unquoted
 		} else if (!has_double) {

--- a/test/values.test.ts
+++ b/test/values.test.ts
@@ -293,8 +293,8 @@ test.each([
 		background-image: url(${input});
 	}`)
 	let expected = `test {
-	background-image: url(${input});
-	background-image: url(${input});
+	background-image: url('${input}');
+	background-image: url('${input}');
 }`
 	expect(actual).toEqual(expected)
 })
@@ -315,6 +315,33 @@ test.each([
 	background-image: url(${input});
 }`
 	expect(actual).toBe(expected)
+})
+
+test('wraps data: URL in single quotes when it contains double quotes', () => {
+	let input = `.a { background: url('data:image/svg+xml,%3Csvg fill="red"%3E%3C/svg%3E'); }`
+	let actual = format(input)
+	let expected = `.a {
+	background: url('data:image/svg+xml,%3Csvg fill="red"%3E%3C/svg%3E');
+}`
+	expect(actual).toEqual(expected)
+})
+
+test('wraps data: URL in double quotes when it contains single quotes', () => {
+	let input = `.a { background: url("data:image/svg+xml,%3Csvg fill='red'%3E%3C/svg%3E"); }`
+	let actual = format(input)
+	let expected = `.a {
+	background: url("data:image/svg+xml,%3Csvg fill='red'%3E%3C/svg%3E");
+}`
+	expect(actual).toEqual(expected)
+})
+
+test('encodes double quotes when data: URL contains both quote types', () => {
+	let input = `.a { background: url('data:image/svg+xml,%3Csvg fill="x" alt=\\'y\\'%3E'); }`
+	let actual = format(input)
+	let expected = `.a {
+	background: url("data:image/svg+xml,%3Csvg fill=%22x%22 alt=\\'y\\'%3E");
+}`
+	expect(actual).toEqual(expected)
 })
 
 test.each([


### PR DESCRIPTION
## Summary
Refactored URL printing logic to intelligently select quote styles for data URIs, ensuring proper formatting when URLs contain quotes.

## Key Changes
- Extracted URL printing logic into a new `print_url()` function for better maintainability
- Updated `print_string()` to accept a configurable quote parameter (defaults to double quotes)
- Implemented smart quote selection for data URIs:
  - Uses unquoted format when no quotes are present
  - Selects single quotes if URL contains double quotes
  - Selects double quotes if URL contains single quotes
  - Encodes double quotes as `%22` when URL contains both quote types
- Added comprehensive test coverage for data URI quote handling scenarios

## Implementation Details
The new `print_url()` function detects data URIs via regex pattern matching and applies quote selection logic only to those URLs. Non-data URLs continue to use standard double-quote wrapping. This approach preserves backward compatibility while fixing edge cases with SVG data URIs that contain quoted attributes.

closes #217 